### PR TITLE
Auth

### DIFF
--- a/MiliDeal/settings.py
+++ b/MiliDeal/settings.py
@@ -213,7 +213,7 @@ SIMPLE_JWT = {
 
     'AUTH_HEADER_TYPES': ('Bearer',),
     'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
-    'USER_ID_FIELD': 'id',
+    'USER_ID_FIELD': 'email',
     'USER_ID_CLAIM': 'user_id',
     'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
 

--- a/user/models.py
+++ b/user/models.py
@@ -47,7 +47,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     objects = UserManager()
 
     # username = models.TextField(max_length=30, unique=True)
-    email = models.EmailField(unique=True)
+    email = models.EmailField(unique=True, primary_key=True)
     nickname = models.CharField(max_length=30, blank=True)
     is_superuser = models.BooleanField(default=False)
     is_active = models.BooleanField(default=True)


### PR DESCRIPTION
![image](https://github.com/milideal/server/assets/57308980/da2ad830-3c62-4277-8181-2218ed747e41)
#17 이 이슈에 올린 user pk 관련 에러와 
로그인/회원가입 시 AttribureError 'User' object has no attribute 'id' 에러가 발생하여
```
# user.models.py
...
    email = models.EmailField(unique=True, primary_key=True)
...
```

```
# settings.py
SIMPLE_JWT = {
...
    'USER_ID_FIELD': 'email'
...
```
위 두 변경사항 PR올립니다. 