### PR TITLE
✨Add 'version_info' endpoin

### DIFF
--- a/MiliDeal/swagger.py
+++ b/MiliDeal/swagger.py
@@ -1,0 +1,16 @@
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="MiliDeal API",
+      default_version='KE3-v1',
+      description="밀리딜 API",
+    #   terms_of_service="서비스약관",
+    #   contact=openapi.Contact(email="담당자"),
+    #   license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=[permissions.AllowAny],
+)

--- a/MiliDeal/urls.py
+++ b/MiliDeal/urls.py
@@ -1,10 +1,8 @@
 """MiliDeal URL Configuration"""
 from django.contrib import admin
 from django.urls import path, include, re_path
-# drf_yasg
-from rest_framework import permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
+# drf_yasg 
+from MiliDeal.swagger import *
 # apps
 from rest_framework import routers
 import mainAPI.urls
@@ -18,24 +16,11 @@ root_router.registry.extend(store.urls.router.registry)
 root_router.registry.extend(user.urls.router.registry)
 root_router.registry.extend(review.urls.router.registry)
 
-schema_view = get_schema_view(
-   openapi.Info(
-      title="MiliDeal API",
-      default_version='KE3-v1',
-      description="밀리딜 API",
-    #   terms_of_service="서비스약관",
-    #   contact=openapi.Contact(email="담당자"),
-    #   license=openapi.License(name="BSD License"),
-   ),
-   public=True,
-   permission_classes=[permissions.AllowAny],
-)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include(root_router.urls)),
-    path('user/', include('user.urls')),
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-]
+] + mainAPI.urls.urlpatterns

--- a/mainAPI/urls.py
+++ b/mainAPI/urls.py
@@ -1,12 +1,11 @@
 from django.urls import path, include
 from rest_framework import routers
-from .views import TestViewSets
+from .views import TestViewSets, version_info
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'test', TestViewSets)
-
 urlpatterns = [
-    path('', include(router.urls))
+    path('version_info', version_info),
 ]
 # [path('some_functional_view_rul', views.functional_view)]
 

--- a/mainAPI/views.py
+++ b/mainAPI/views.py
@@ -2,7 +2,14 @@ from rest_framework.viewsets import ModelViewSet
 from .serializers import TestSerializer
 from .models import TestModel
 from Util.decorators import convert_objectId
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 
+@csrf_exempt
+def version_info(request):
+    if request.method == 'GET':
+        return JsonResponse({"data_amount":"886",
+                             "last_update":"2023-10-07"})
 
 class TestViewSets(ModelViewSet):
     queryset = TestModel.objects.all()


### PR DESCRIPTION
## 변경 사항

이 PR은 다음의 세 가지 변경 사항을 포함합니다:

1. **♻️Separate 'drf_yasg' URL handling codee**: 'drf_yasg'의 URL 관련 코드를 분리하여 코드의 모듈성을 향상시켰습니다.

2. **✨Add 'version_info' endpoint**: API 버전 정보를 제공하는 'version_info' Endpoint를 추가했습니다.

3. **✨Add 'version_info' FBV**: 'version_info' Endpoint를 위한 Function-Based View (FBV)를 추가했습니다.

## 상세 내용

1. **♻️Separate 'drf_yasg' URL handling code**
   - 'drf_yasg'의 URL 관련 코드를 `Milideal.swagger.py`로 분리하여 `Milideal.urls.py` 에 코드가 몰리는 것을 해소했습니다.
2. **✨Add 'version_info' endpoint**:
   - 'version_info' endpoint는 `Milideal.urls.py`에서 `mainAPI.urls.urlpatterns`를 참조합니다.
3. **✨Add 'version_info' FBV**:
   - 'version_info' endpoint를 위한 Function-Based View (FBV)를 추가하여 literal 응답으로 처리합니다.
   - 추후에 가맹점 개수 변화 시 API 정보가 업데이트 되는 자동화가 되어도 좋을 것 같습니다.


# PS
큰 수정 사항이 없어서 바로 merge 하겠습니다